### PR TITLE
Fix monitor leak in Xandra.Connection

### DIFF
--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -75,6 +75,7 @@ defmodule Xandra.Connection do
           # If the prepared query was in the cache, we emit a Telemetry event and we must
           # make sure to put the stream ID we checked out back into the pool.
           {:ok, prepared} ->
+            Process.demonitor(req_alias, [:flush])
             :telemetry.execute([:xandra, :prepared_cache, :hit], %{}, metadata)
             :gen_statem.cast(conn_pid, {:release_stream_id, stream_id})
             {:ok, prepared}
@@ -106,6 +107,7 @@ defmodule Xandra.Connection do
                 end
               else
                 {:error, reason} ->
+                  Process.demonitor(req_alias, [:flush])
                   reason = ConnectionError.new("prepare", reason)
                   {{:error, reason}, Map.put(metadata, :reason, reason)}
               end
@@ -113,6 +115,7 @@ defmodule Xandra.Connection do
         end
 
       {:error, error} ->
+        Process.demonitor(req_alias, [:flush])
         {:error, ConnectionError.new("check out connection", error)}
     end
   end
@@ -182,6 +185,7 @@ defmodule Xandra.Connection do
             end
           else
             {:error, reason} ->
+              Process.demonitor(req_alias, [:flush])
               {:error, ConnectionError.new("execute", reason)}
           end
         end
@@ -196,6 +200,7 @@ defmodule Xandra.Connection do
         end)
 
       {:error, error} ->
+        Process.demonitor(req_alias, [:flush])
         {:error, ConnectionError.new("check out connection", error)}
     end
   end


### PR DESCRIPTION
When calling prepare or execute on a connection, a monitor is started on that connection which is configured to be removed when it receives a reply using the created alias. However it does not always receive a reply using that alias, which can lead to a resource leak where monitors are created and never removed.

This is mostly (only?) a problem when calling prepare on a long running connection from a long running process when the prepared query already is in the cache, because then the connection does not send a reply using the alias. The leaked monitors eventually takes up enough memory to crash the application. In my case, after a few hours.

Example before fix:
```
iex> Process.info(pid(0, 704 ,0), :dictionary) |> elem(1) |> Enum.take(1)
["$initial_call": {Xandra.Connection, :init, 1}]
iex> Process.info(pid(0, 704 ,0), :monitored_by) |> elem(1) |> length()
105236
```

By explicitly demonitoring when a reply is not guaranteed, the resource leak is fixed.

Example after fix:
```
iex> Process.info(pid(0, 722 ,0), :dictionary) |> elem(1) |> Enum.take(1)
["$initial_call": {Xandra.Connection, :init, 1}]
iex> Process.info(pid(0, 722 ,0), :monitored_by) |> elem(1) |> length()
0
```