### PR TITLE
Fix memory leak in Xandra.Connection

### DIFF
--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -681,7 +681,6 @@ defmodule Xandra.Connection do
         |> handle_frame(frame)
         |> handle_new_bytes()
 
-      # TODO: Is the stream id released here?
       {:error, :insufficient_data} ->
         {:keep_state, data}
 


### PR DESCRIPTION
Fixed the memory leak in `Xandra.Connection` that was caused by not releasing stream ids.

This is how the memory usage of our application looks like after the fix at 08.02 around 10:00:

<img width="840" alt="Screenshot 2024-02-09 at 11 31 39" src="https://github.com/whatyouhide/xandra/assets/23001154/637c8e1a-4c70-4048-9c23-bc1fe8a0379d">
