### PR TITLE
Fix decoding multiple frames in a single envelope in native protocol v5

### DIFF
--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -646,7 +646,6 @@ defmodule Xandra.Connection do
   def connected(:info, message, data) when is_data_message(data.transport, message) do
     :ok = Transport.setopts(data.transport, active: :once)
     {_mod, _socket, bytes} = message
-
     data = update_in(data.buffer, &(&1 <> bytes))
     handle_new_bytes(data)
   end

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -182,6 +182,7 @@ defmodule Xandra.Connection do
         # This is in an anonymous function so that we can use it in a Telemetry span.
         fun = fn ->
           with :ok <- Transport.send(transport, payload),
+               Logger.debug("Sent query on stream ID #{stream_id}, will wait for an answer"),
                {:ok, %Frame{} = frame} <-
                  receive_response_frame(conn_pid, req_alias, checked_out_state, timeout) do
             case protocol_module.decode_response(frame, query, options) do

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -344,7 +344,8 @@ defmodule Xandra.Connection do
     in_flight_requests: %{},
     timed_out_ids: %{},
     current_keyspace: nil,
-    buffer: <<>>
+    buffer: <<>>,
+    free_stream_ids: Enum.to_list(1..@max_cassandra_stream_id)
   ]
 
   ## Callbacks
@@ -558,6 +559,7 @@ defmodule Xandra.Connection do
 
   def disconnected(:cast, {:release_stream_id, stream_id}, %__MODULE__{} = data) do
     data = update_in(data.in_flight_requests, &Map.delete(&1, stream_id))
+    data = update_in(data.free_stream_ids, &[stream_id | &1])
     {:keep_state, data}
   end
 
@@ -593,7 +595,7 @@ defmodule Xandra.Connection do
         {:error, reason} -> disconnect(data, reason)
       end
     else
-      case Transport.setopts(data.transport, active: :once) do
+      case Transport.setopts(data.transport, active: true) do
         :ok -> {:keep_state_and_data, {{:timeout, :reconnect}, :infinity, nil}}
         {:error, reason} -> disconnect(data, reason)
       end
@@ -613,7 +615,8 @@ defmodule Xandra.Connection do
   # sends us the corresponding response, we can still route that C* response to the
   # alias and it'll not go anywhere and not cause any issues.
   def connected({:call, from}, {:checkout_state_for_next_request, req_alias}, data) do
-    stream_id = random_free_stream_id(data.in_flight_requests, data.timed_out_ids)
+    # stream_id = random_free_stream_id(data.in_flight_requests, data.timed_out_ids)
+    {stream_id, data} = next_stream_id(data)
 
     response =
       checked_out_state(
@@ -647,8 +650,13 @@ defmodule Xandra.Connection do
   end
 
   def connected(:info, message, data) when is_data_message(data.transport, message) do
-    :ok = Transport.setopts(data.transport, active: :once)
+    :ok = Transport.setopts(data.transport, active: true)
     {_mod, _socket, bytes} = message
+
+    Logger.debug(
+      "Received data:\n#{inspect(bytes, limit: :infinity, iexprintable_limit: :infinity)}"
+    )
+
     data = update_in(data.buffer, &(&1 <> bytes))
     handle_new_bytes(data)
   end
@@ -669,6 +677,7 @@ defmodule Xandra.Connection do
   def connected(:cast, {:release_stream_id, stream_id}, %__MODULE__{} = data) do
     Logger.debug("Releasing stream ID #{stream_id}")
     data = update_in(data.in_flight_requests, &Map.delete(&1, stream_id))
+    data = update_in(data.free_stream_ids, &[stream_id | &1])
     {:keep_state, data}
   end
 
@@ -767,9 +776,15 @@ defmodule Xandra.Connection do
            _rest_fun = & &1
          ) do
       {:ok, frame, rest} ->
-        %__MODULE__{data | buffer: rest}
-        |> handle_frame(frame)
-        |> handle_new_bytes()
+        Logger.debug("Received full frame")
+        data = handle_frame(%__MODULE__{data | buffer: rest}, frame)
+
+        if rest != "" do
+          handle_new_bytes(data)
+        else
+          Logger.debug("No more frames to decode")
+          {:keep_state, data}
+        end
 
       {:error, :insufficient_data} ->
         Logger.debug("Received a packet that did not contain a full frame")
@@ -922,6 +937,12 @@ defmodule Xandra.Connection do
       metadata = telemetry_meta(resp, conn_pid, %{query: query})
       :telemetry.execute([:xandra, :server_warnings], %{warnings: warnings}, metadata)
     end
+  end
+
+  defp next_stream_id(data) do
+    [next_id | rest] = data.free_stream_ids
+    data = %__MODULE__{data | free_stream_ids: rest}
+    {next_id, data}
   end
 
   defp random_free_stream_id(in_flight_requests, timed_out_ids) do

--- a/lib/xandra/connection/utils.ex
+++ b/lib/xandra/connection/utils.ex
@@ -13,9 +13,15 @@ defmodule Xandra.Connection.Utils do
            do: {:ok, binary, fetch_state}
     end
 
-    case protocol_format do
-      :v4_or_less -> Frame.decode_v4(fetch_bytes_fun, :no_fetch_state, compressor)
-      :v5_or_more -> Frame.decode_v5(fetch_bytes_fun, :no_fetch_state, compressor)
+    decode_fun =
+      case protocol_format do
+        :v4_or_less -> &Frame.decode_v4/3
+        :v5_or_more -> &Frame.decode_v5/3
+      end
+
+    case decode_fun.(fetch_bytes_fun, :no_fetch_state, compressor) do
+      {:ok, [frame], rest} -> {:ok, frame, rest}
+      {:error, reason} -> {:error, reason}
     end
   end
 


### PR DESCRIPTION
@jvf @harunzengin this PR can be a collaborative attempt at figuring out what the flying horse crab hell is going on with #356.

At the time of opening it, the PR only adds a test to reproduce the timeouts (which does reproduce them ~90% of the time in my experience) and some additional logging.

Most of the time, Xandra *does not receive the frame* that times out. This is weird. I’m running this with a locally-running Dockerized Cassandra in case it helps.

Btw, I’m opening this because I won't have a ton of time to dedicate to this as I’m pretty busy at work, but I figured we can dig in together, especially after @jvf's fantastic reproducing steps and tests in #356 🙃 