### PR TITLE
Fix docker compose in Github Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Start Docker and wait for it to be up
         run: |
-          docker-compose up --detach --build
+          docker compose up --detach --build
           ./test/docker/health-check-services.sh
 
       - name: Install OTP and Elixir


### PR DESCRIPTION
Docker Compose v1 has been removed from the Ubuntu base image.

You can see the announcement in the actions of the last commit in `main`: Go to one of last jobs, e.g. 
[Test (Elixir 1.17.1, OTP 27.0 — C* 4.1, Scylla 5.2](https://github.com/whatyouhide/xandra/actions/runs/9927802204/job/27423221142), open the "Set up job" details, open "Runner Image" details and follow the [Included Software](https://github.com/actions/runner-images/blob/ubuntu22/20240708.1/images/ubuntu/Ubuntu2204-Readme.md) link which announces [Docker Compose v1 will be removed from images on July, 29](https://github.com/actions/runner-images/issues/9692).

Now actions fail with `docker-compose: command not found`, see for example [here](https://github.com/sonnen/xandra/actions/runs/10831420568). To fix this, we need to run it as `docker compose`.