### PR TITLE
Reconnect after all nodes were offline

### DIFF
--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -121,6 +121,9 @@ defmodule Xandra.Cluster.ControlConnection do
 
         execute_telemetry(state, [:control_connection, :connected], %{}, %{})
 
+        # We know that the node we just connected to is up
+        send(state.cluster_pid, {:host_up, state.ip, state.port})
+
         # We set up a timer to periodically refresh the topology.
         schedule_refresh_topology(state.refresh_topology_interval)
 

--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -319,6 +319,7 @@ defmodule Xandra.Cluster.Pool do
     # Not connected anymore, but we're not really sure if the whole host is down.
     data = set_host_status(data, peername, :up)
     data = stop_pool(data, data.peers[peername].host)
+    # There might be more hosts that we could connect to instead of the stopped one
     data = maybe_start_pools(data)
     {:keep_state, data}
   end
@@ -334,6 +335,7 @@ defmodule Xandra.Cluster.Pool do
       data = set_host_status(data, peername, :down)
       host = data.peers[peername].host
       data = stop_pool(data, host)
+      # There might be more hosts that we could connect to instead of the stopped one
       data = maybe_start_pools(data)
       {:keep_state, data}
     else

--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -318,6 +318,8 @@ defmodule Xandra.Cluster.Pool do
       when is_peername(peername) do
     # Not connected anymore, but we're not really sure if the whole host is down.
     data = set_host_status(data, peername, :up)
+    data = stop_pool(data, data.peers[peername].host)
+    data = maybe_start_pools(data)
     {:keep_state, data}
   end
 
@@ -502,11 +504,14 @@ defmodule Xandra.Cluster.Pool do
     lb_callback =
       case new_status do
         :up -> :host_up
-        :down -> :host_down 
+        :down -> :host_down
         :connected -> :host_connected
       end
 
-    update_in(data.load_balancing_state, &apply(data.load_balancing_module, lb_callback, [&1, host]))
+    update_in(
+      data.load_balancing_state,
+      &apply(data.load_balancing_module, lb_callback, [&1, host])
+    )
   end
 
   defp stop_pool(data, %Host{} = host) do

--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -499,16 +499,14 @@ defmodule Xandra.Cluster.Pool do
         {host, %{peer | status: new_status}}
       end)
 
-    case new_status do
-      :up ->
-        update_in(data.load_balancing_state, &data.load_balancing_module.host_up(&1, host))
+    lb_callback =
+      case new_status do
+        :up -> :host_up
+        :down -> :host_down 
+        :connected -> :host_connected
+      end
 
-      :down ->
-        update_in(data.load_balancing_state, &data.load_balancing_module.host_down(&1, host))
-
-      :connected ->
-        update_in(data.load_balancing_state, &data.load_balancing_module.host_connected(&1, host))
-    end
+    update_in(data.load_balancing_state, &apply(data.load_balancing_module, lb_callback, [&1, host]))
   end
 
   defp stop_pool(data, %Host{} = host) do

--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -499,8 +499,6 @@ defmodule Xandra.Cluster.Pool do
         {host, %{peer | status: new_status}}
       end)
 
-    Logger.info("Setting #{new_status} for #{inspect(peername)}")
-
     case new_status do
       :up ->
         update_in(data.load_balancing_state, &data.load_balancing_module.host_up(&1, host))

--- a/test/xandra/cluster_test.exs
+++ b/test/xandra/cluster_test.exs
@@ -839,7 +839,9 @@ defmodule Xandra.ClusterTest do
       opts = Keyword.merge(opts, sync_connect: 1000)
       cluster = start_link_supervised!({Cluster, opts})
 
-      assert %{pool_pid: pool_pid, status: :connected, host: host} = get_state(cluster).peers[{{127, 0, 0, 1}, @port}]
+      assert %{pool_pid: pool_pid, status: :connected, host: host} =
+               get_state(cluster).peers[{{127, 0, 0, 1}, @port}]
+
       assert get_load_balancing_state(get_state(cluster), host) == :connected
 
       assert {:ok, [{conn_pid, %Host{}}]} = Pool.checkout(cluster)
@@ -848,7 +850,9 @@ defmodule Xandra.ClusterTest do
       Process.exit(conn_pid, :kill)
       assert_receive {:DOWN, ^ref, _, _, _}
 
-      assert %{pool_pid: ^pool_pid, status: :connected, host: host} = get_state(cluster).peers[{{127, 0, 0, 1}, @port}]
+      assert %{pool_pid: ^pool_pid, status: :connected, host: host} =
+               get_state(cluster).peers[{{127, 0, 0, 1}, @port}]
+
       assert get_load_balancing_state(get_state(cluster), host) == :connected
     end
 
@@ -970,7 +974,11 @@ defmodule Xandra.ClusterTest do
   end
 
   defp get_load_balancing_state(%Pool{load_balancing_state: lbs}, %Host{} = host) do
-    {_host, state} = Enum.find(lbs, fn {lbs_host, _state} -> Host.to_peername(lbs_host) == Host.to_peername(host) end)
+    {_host, state} =
+      Enum.find(lbs, fn {lbs_host, _state} ->
+        Host.to_peername(lbs_host) == Host.to_peername(host)
+      end)
+
     state
   end
 


### PR DESCRIPTION
Fixes the reconnectivity issue after all nodes were down.

Sends a `:host_up` event whenever a new control connection is established so that `Xandra.Cluster.Pool` can start a pool and connect to that host.

Also, fixes the issue where the load balancing state diverges from the peers state.

Closes #373.