### PR TITLE
Support `ANY` consistency level

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -275,6 +275,7 @@ defmodule Xandra do
           {module(), function_name :: atom(), [term()]} | (keyword() -> keyword())
 
   @valid_consistencies [
+    :any,
     :one,
     :two,
     :three,

--- a/test/integration/any_consistency_test.exs
+++ b/test/integration/any_consistency_test.exs
@@ -1,0 +1,22 @@
+defmodule AnyConsistencyTest do
+  use XandraTest.IntegrationCase, async: true
+
+  # Regression for: https://github.com/lexhide/xandra/issues/381
+  test "queries with :any consistency are correctly executed", %{conn: conn} do
+    statement = "CREATE TABLE cyclists (first_name text, last_name text PRIMARY KEY)"
+    Xandra.execute!(conn, statement, %{}, consistency: :any)
+
+    statement = "INSERT INTO cyclists (first_name, last_name) VALUES (:first_name, :last_name)"
+
+    {:ok, %Xandra.Void{}} =
+      Xandra.execute(
+        conn,
+        statement,
+        %{
+          "first_name" => {"text", "KRUIKSWIJK"},
+          "last_name" => {"text", "Steven"}
+        },
+        consistency: :any
+      )
+  end
+end


### PR DESCRIPTION
`ANY` is the lowest possible CL for writes. Allow queries to run with `:any` consistency instead of crashing.

Closes #380